### PR TITLE
fix(compaction): show it, and let Stop reach it

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -461,10 +461,12 @@ app.post("/api/sessions/:id/compact", async (req, res) => {
   const session = getSession(req.params.id);
   if (!session) return res.status(404).json({ error: "Not found" });
   try {
-    const client = await sessions.client(session.id);
-    await client.compact();
+    await sessions.compact(session.id);
     res.json({ ok: true });
   } catch (e) {
+    // The message alone reaches the browser, and "Cannot read properties of
+    // undefined" says nothing about where. The stack stays here.
+    console.error(`[portal] compaction failed for ${session.id}:`, e);
     res.status(500).json({ error: (e as Error).message });
   }
 });

--- a/server/src/pi/sdk-client.ts
+++ b/server/src/pi/sdk-client.ts
@@ -459,6 +459,10 @@ export class SdkPiClient extends EventEmitter implements PiClient {
   }
 
   async abort(): Promise<void> {
+    // Compaction runs on a controller of its own, so session.abort() stops an
+    // agent run and leaves a summarisation going — the one case where Stop
+    // looks like it did nothing at all.
+    if (this.session.isCompacting) this.session.abortCompaction();
     await this.session.abort();
   }
 

--- a/server/src/session-manager.ts
+++ b/server/src/session-manager.ts
@@ -126,22 +126,31 @@ class SessionManager extends EventEmitter {
    * indistinguishable from a hung portal.
    */
   async compact(sessionId: string): Promise<void> {
+    // One at a time. A second request used to overwrite the tracked promise,
+    // and whichever finished first then cleared it and published idle while
+    // the other was still going — which is exactly the state prompt() checks
+    // for before deciding it is safe to start.
+    const inFlight = this.compacting.get(sessionId);
+    if (inFlight) return inFlight;
+
     // Before starting pi, not after: on a cold session that takes seconds, and
     // those are exactly the seconds with no activity line and no Stop.
     this.mark(sessionId, "running");
     const run = (async () => {
       const client = await this.ensureClient(sessionId);
+      // Stop pressed while pi was still starting. There was nothing to abort
+      // at the time, so it is honoured here instead of starting a compaction
+      // that the user has already asked not to happen.
+      if (this.cancelPending.delete(sessionId)) return;
       await client.compact();
     })();
-    // Held so a Stop can wait for it — see abort().
-    this.compacting.set(sessionId, run.then(
-      () => {},
-      () => {},
-    ));
+    // Held so a Stop, and the next prompt, can wait for it — see abort().
+    this.compacting.set(sessionId, run);
     try {
       await run;
     } finally {
       this.compacting.delete(sessionId);
+      this.cancelPending.delete(sessionId);
       // No agent run, so no agent_settled arrives to clear it.
       this.mark(sessionId, "idle");
     }
@@ -249,6 +258,9 @@ class SessionManager extends EventEmitter {
    * pi has unwound it, and both Stop and the next prompt have to wait.
    */
   private compacting = new Map<string, Promise<void>>();
+
+  /** A Stop that arrived before there was anything to stop. */
+  private cancelPending = new Set<string>();
 
   /** Move a session's status and tell whoever is watching, in that order. */
   private mark(sessionId: string, status: "running" | "idle"): void {
@@ -571,7 +583,13 @@ class SessionManager extends EventEmitter {
 
   async abort(sessionId: string): Promise<void> {
     const live = this.live.get(sessionId);
-    if (!live?.client.running) return;
+    if (!live?.client.running) {
+      // Nothing to abort yet — but a compaction waiting on pi to start is
+      // still going to run, and the session already shows as working with a
+      // Stop button. Remembered so it is cancelled the moment it could begin.
+      if (this.compacting.has(sessionId)) this.cancelPending.add(sessionId);
+      return;
+    }
     await live.client.abort().catch(() => {});
     // Cancelling a compaction does not end it. pi detaches the session from
     // agent events for the whole of compact() and reattaches in its own
@@ -598,7 +616,9 @@ class SessionManager extends EventEmitter {
     let timer: NodeJS.Timeout | undefined;
     try {
       await Promise.race([
-        inFlight,
+        // Waiting for it to be over, not for it to have worked. The failure
+        // belongs to whoever asked for the compaction.
+        inFlight.catch(() => {}),
         new Promise<void>((resolve) => {
           timer = setTimeout(resolve, timeoutMs);
         }),

--- a/server/src/session-manager.ts
+++ b/server/src/session-manager.ts
@@ -281,6 +281,10 @@ class SessionManager extends EventEmitter {
     // Same reason as in abort(): a session mid-compaction is detached from
     // agent events, and a prompt started there is invisible.
     await this.settleCompaction(sessionId);
+    // The compaction published idle on its way out, after this prompt had
+    // already claimed the session. Without this the composer loses its Stop
+    // and isBusy() reads false for however long pi takes to answer.
+    this.mark(sessionId, "running");
     try {
       await this.submit(sessionId, message);
     } catch (e) {
@@ -610,26 +614,33 @@ class SessionManager extends EventEmitter {
   /**
    * Resolves once any in-flight compaction has finished unwinding.
    *
-   * Bounded, because both callers are the ones you reach for when something is
-   * already wrong: waiting forever on a compaction that never returns would
-   * take Stop down with it and leave the session unusable until a restart.
-   * Giving up puts us back where this started, which is survivable.
+   * Bounded, and it gives up by failing rather than by carrying on. A race
+   * does not cancel what it lost to: the compaction is still running, the
+   * session is still detached from agent events, and proceeding anyway would
+   * start a turn that reaches nobody — which is the thing this wait exists to
+   * prevent. Saying so leaves the session honestly busy, and the cancellation
+   * Stop already issued still lands when the compaction finally unwinds.
    */
   private async settleCompaction(sessionId: string, timeoutMs = 60_000): Promise<void> {
     const inFlight = this.compacting.get(sessionId);
     if (!inFlight) return;
     let timer: NodeJS.Timeout | undefined;
-    try {
-      await Promise.race([
-        // Waiting for it to be over, not for it to have worked. The failure
-        // belongs to whoever asked for the compaction.
-        inFlight.catch(() => {}),
-        new Promise<void>((resolve) => {
-          timer = setTimeout(resolve, timeoutMs);
-        }),
-      ]);
-    } finally {
-      if (timer) clearTimeout(timer);
+    const settled = await Promise.race([
+      // Waiting for it to be over, not for it to have worked. The failure
+      // belongs to whoever asked for the compaction.
+      inFlight.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+    if (!settled) {
+      throw new Error(
+        "The conversation is still being compacted. Nothing else can run until it finishes.",
+      );
     }
   }
 

--- a/server/src/session-manager.ts
+++ b/server/src/session-manager.ts
@@ -126,11 +126,22 @@ class SessionManager extends EventEmitter {
    * indistinguishable from a hung portal.
    */
   async compact(sessionId: string): Promise<void> {
-    const client = await this.ensureClient(sessionId);
+    // Before starting pi, not after: on a cold session that takes seconds, and
+    // those are exactly the seconds with no activity line and no Stop.
     this.mark(sessionId, "running");
-    try {
+    const run = (async () => {
+      const client = await this.ensureClient(sessionId);
       await client.compact();
+    })();
+    // Held so a Stop can wait for it — see abort().
+    this.compacting.set(sessionId, run.then(
+      () => {},
+      () => {},
+    ));
+    try {
+      await run;
     } finally {
+      this.compacting.delete(sessionId);
       // No agent run, so no agent_settled arrives to clear it.
       this.mark(sessionId, "idle");
     }
@@ -233,6 +244,12 @@ class SessionManager extends EventEmitter {
     return client;
   }
 
+  /**
+   * Compaction in flight, per session. A cancelled one is still running until
+   * pi has unwound it, and both Stop and the next prompt have to wait.
+   */
+  private compacting = new Map<string, Promise<void>>();
+
   /** Move a session's status and tell whoever is watching, in that order. */
   private mark(sessionId: string, status: "running" | "idle"): void {
     if (getSession(sessionId)?.status === status) return;
@@ -249,6 +266,9 @@ class SessionManager extends EventEmitter {
    */
   async prompt(sessionId: string, message: string): Promise<void> {
     this.mark(sessionId, "running");
+    // Same reason as in abort(): a session mid-compaction is detached from
+    // agent events, and a prompt started there is invisible.
+    await this.settleCompaction(sessionId);
     try {
       await this.submit(sessionId, message);
     } catch (e) {
@@ -553,8 +573,39 @@ class SessionManager extends EventEmitter {
     const live = this.live.get(sessionId);
     if (!live?.client.running) return;
     await live.client.abort().catch(() => {});
+    // Cancelling a compaction does not end it. pi detaches the session from
+    // agent events for the whole of compact() and reattaches in its own
+    // finally, so between abortCompaction() returning and that finally running
+    // the session is deaf. Publishing idle there lets the next prompt start
+    // against a detached session — it would run with nothing reaching the
+    // transcript, which is the failure this whole area keeps producing.
+    await this.settleCompaction(sessionId);
     updateSession(sessionId, { status: "idle" });
     this.record(sessionId, "portal_status", { status: "idle", aborted: true });
+  }
+
+  /**
+   * Resolves once any in-flight compaction has finished unwinding.
+   *
+   * Bounded, because both callers are the ones you reach for when something is
+   * already wrong: waiting forever on a compaction that never returns would
+   * take Stop down with it and leave the session unusable until a restart.
+   * Giving up puts us back where this started, which is survivable.
+   */
+  private async settleCompaction(sessionId: string, timeoutMs = 60_000): Promise<void> {
+    const inFlight = this.compacting.get(sessionId);
+    if (!inFlight) return;
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        inFlight,
+        new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, timeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   async stop(sessionId: string): Promise<void> {

--- a/server/src/session-manager.ts
+++ b/server/src/session-manager.ts
@@ -117,6 +117,25 @@ class SessionManager extends EventEmitter {
     this.emit(`session:${sessionId}`, row);
   }
 
+  /**
+   * Compact on request.
+   *
+   * Marked running for the same reason a prompt is: it takes a model call and
+   * a minute, and without it the composer showed nothing, the transcript
+   * showed nothing, and there was no Stop to press — a long compaction was
+   * indistinguishable from a hung portal.
+   */
+  async compact(sessionId: string): Promise<void> {
+    const client = await this.ensureClient(sessionId);
+    this.mark(sessionId, "running");
+    try {
+      await client.compact();
+    } finally {
+      // No agent run, so no agent_settled arrives to clear it.
+      this.mark(sessionId, "idle");
+    }
+  }
+
   /** How far llama.cpp has got through the prompt. Straight out to the browser. */
   reportPrefill(sessionId: string, prefill: unknown): void {
     this.record(sessionId, "portal_prefill", prefill);

--- a/server/src/session-manager.ts
+++ b/server/src/session-manager.ts
@@ -588,6 +588,11 @@ class SessionManager extends EventEmitter {
       // still going to run, and the session already shows as working with a
       // Stop button. Remembered so it is cancelled the moment it could begin.
       if (this.compacting.has(sessionId)) this.cancelPending.add(sessionId);
+      // Then waited for, like the path below. Returning here reported the Stop
+      // as done while the session went on showing itself as compacting until pi
+      // had finished starting — the same bounded wait, so the answer arrives
+      // when the thing it describes is actually over.
+      await this.settleCompaction(sessionId);
       return;
     }
     await live.client.abort().catch(() => {});


### PR DESCRIPTION
## What was wrong

Pressing **Compact now** went straight to pi, so the portal never marked the session as working. That meant:

- no activity line — the transcript said nothing at all
- no Stop button, since it only renders while a session is running
- and Stop wouldn't have helped anyway: compaction runs on its own abort controller, and `session.abort()` only ends an agent run

A long compaction was indistinguishable from a hung portal.

## What changed

- Compaction is marked running like any other work, so the activity line shows **"compacting the conversation"** with a timer. `transcript.ts` already had the label; nothing was ever setting the status that gates it.
- `abort()` calls `abortCompaction()` when `isCompacting`, so Stop reaches it.
- Status is cleared in a `finally` — there's no agent run, so no `agent_settled` arrives to clear it.
- The compact route logs the stack. `Cannot read properties of undefined (reading 'signal')` reaches the browser with nothing to locate it by, because the API returns only `e.message`.

## Still open

The `signal` error itself is **not fixed here** — I traced pi's compact path and every `.signal` in it is optional-chained, so I can't place it by reading. The logging above is what will show where it comes from on the next attempt.

## Testing

Typecheck and web build pass. Not exercised against a live compaction — that needs a session I can't start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session compaction reliability and status handling.
  - Prevented overlapping compaction operations.
  - Stopping an active session now cancels ongoing or starting compaction.
  - Session actions wait for compaction to finish before proceeding.
  - Compaction failures retain the existing error response while being logged for troubleshooting.
  - Added safeguards against sessions becoming unresponsive during compaction, including a timeout for stalled operations.
  - Ensured cancellation state is cleared after compaction completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->