### PR TITLE
feat(compaction): a slider for how much a compaction keeps

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -41,7 +41,12 @@ import { startLlamaProxy } from "./llama-progress.js";
 import { pinConnection } from "./api/browser.js";
 import { routineSupervisor } from "./routines/supervisor.js";
 import { channelSupervisor } from "./channels/supervisor.js";
-import { piSettingsPath } from "./pi-settings.js";
+import {
+  COMPACTION_DEFAULTS,
+  piSettingsPath,
+  readCompactionSettings,
+  writeCompactionSettings,
+} from "./pi-settings.js";
 import { eventTime, getDb } from "./db.js";
 import { getBuiltinCommands } from "./pi/builtins.js";
 import { isValidSlug, slugify } from "./slug.js";
@@ -96,21 +101,50 @@ app.get("/api/settings", (_req, res) => {
     stored: getStoredSettings(),
     defaults: getSettingDefaults(),
     piSettingsPath: piSettingsPath(),
+    // pi's own, not the portal's — kept separate in the response so the UI can
+    // say which file a value lives in.
+    compaction: readCompactionSettings(),
+    compactionDefaults: COMPACTION_DEFAULTS,
     executor: EXECUTOR_KIND,
     workspaceRoot: WORKSPACE_ROOT,
   });
 });
 
-app.put("/api/settings", (req, res) => {
+app.put("/api/settings", async (req, res) => {
   const { provider, model, thinkingLevel } = req.body ?? {};
   const patch: Record<string, string> = {};
   if (typeof provider === "string") patch.provider = provider.trim();
   if (typeof model === "string") patch.model = model.trim();
   if (typeof thinkingLevel === "string") patch.thinkingLevel = thinkingLevel.trim();
   const settings = setSettings(patch);
-  // Existing sessions keep their own settings; this applies to sessions started
-  // from here on, which matches how the TUI treats a changed default.
-  res.json({ settings, note: "Applies to newly started sessions" });
+
+  // Compaction lives in pi's file rather than the portal's, because pi is what
+  // reads it. Rejected rather than clamped: a number typed by hand into a box
+  // that silently becomes a different number is worse than being told.
+  const keep = req.body?.keepRecentTokens;
+  let compaction = readCompactionSettings();
+  if (keep !== undefined) {
+    const tokens = Number(keep);
+    if (!Number.isFinite(tokens) || tokens < 1000 || tokens > 500_000) {
+      return res.status(400).json({ error: "Keep recent must be between 1,000 and 500,000 tokens" });
+    }
+    compaction = writeCompactionSettings({ keepRecentTokens: Math.round(tokens) });
+  }
+
+  // The provider and model defaults apply to sessions started from here on,
+  // which matches how the TUI treats a changed default. Compaction is pushed
+  // into open sessions as well — the session you are looking at when you
+  // change it is the one you meant it for.
+  const refreshed = keep !== undefined ? await sessions.refreshSettings() : 0;
+  res.json({
+    settings,
+    compaction,
+    refreshed,
+    note:
+      keep !== undefined
+        ? `Compaction applied to ${refreshed} open session${refreshed === 1 ? "" : "s"}. Model and effort apply to newly started sessions.`
+        : "Applies to newly started sessions",
+  });
 });
 
 // --- workspaces ---

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -116,32 +116,41 @@ app.put("/api/settings", async (req, res) => {
   if (typeof provider === "string") patch.provider = provider.trim();
   if (typeof model === "string") patch.model = model.trim();
   if (typeof thinkingLevel === "string") patch.thinkingLevel = thinkingLevel.trim();
-  const settings = setSettings(patch);
-
-  // Compaction lives in pi's file rather than the portal's, because pi is what
-  // reads it. Rejected rather than clamped: a number typed by hand into a box
-  // that silently becomes a different number is worse than being told.
+  // Checked before anything is written. Rejecting half way through left the
+  // provider changed on a request that answered 400, which is a worse outcome
+  // than either accepting or refusing the lot. Rejected rather than clamped
+  // too: a number that silently becomes a different number is worse than being
+  // told it was wrong.
   const keep = req.body?.keepRecentTokens;
-  let compaction = readCompactionSettings();
+  let tokens: number | undefined;
   if (keep !== undefined) {
-    const tokens = Number(keep);
+    tokens = Number(keep);
     if (!Number.isFinite(tokens) || tokens < 1000 || tokens > 500_000) {
       return res.status(400).json({ error: "Keep recent must be between 1,000 and 500,000 tokens" });
     }
-    compaction = writeCompactionSettings({ keepRecentTokens: Math.round(tokens) });
+    tokens = Math.round(tokens);
   }
+
+  const settings = setSettings(patch);
+
+  // Compaction lives in pi's file rather than the portal's, because pi is what
+  // reads it.
+  const compaction =
+    tokens !== undefined
+      ? await writeCompactionSettings({ keepRecentTokens: tokens })
+      : readCompactionSettings();
 
   // The provider and model defaults apply to sessions started from here on,
   // which matches how the TUI treats a changed default. Compaction is pushed
   // into open sessions as well — the session you are looking at when you
   // change it is the one you meant it for.
-  const refreshed = keep !== undefined ? await sessions.refreshSettings() : 0;
+  const refreshed = tokens !== undefined ? await sessions.refreshSettings() : 0;
   res.json({
     settings,
     compaction,
     refreshed,
     note:
-      keep !== undefined
+      tokens !== undefined
         ? `Compaction applied to ${refreshed} open session${refreshed === 1 ? "" : "s"}. Model and effort apply to newly started sessions.`
         : "Applies to newly started sessions",
   });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -122,6 +122,22 @@ app.put("/api/settings", async (req, res) => {
   // too: a number that silently becomes a different number is worse than being
   // told it was wrong.
   const keep = req.body?.keepRecentTokens;
+
+  // The two live in different stores — the portal's database and pi's own
+  // settings file — and there is no way to write both or neither. Committing
+  // one and failing the other would answer with an error after half the change
+  // had landed, so a request is not allowed to ask for both. Nothing sends
+  // one: the sliders save on release, on their own, and Save defaults carries
+  // only the fields above it.
+  const wantsDefaults = ["provider", "model", "thinkingLevel"].some(
+    (k) => typeof req.body?.[k] === "string",
+  );
+  if (keep !== undefined && wantsDefaults) {
+    return res.status(400).json({
+      error: "Save the session defaults and the compaction setting separately — they are stored in different files",
+    });
+  }
+
   let tokens: number | undefined;
   if (keep !== undefined) {
     tokens = Number(keep);

--- a/server/src/pi-settings.ts
+++ b/server/src/pi-settings.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 /**
@@ -28,4 +28,48 @@ export function readPiSettings(): Record<string, unknown> {
 export function piSetting(key: string): string | undefined {
   const value = readPiSettings()[key];
   return typeof value === "string" && value ? value : undefined;
+}
+
+/**
+ * How compaction is tuned, from pi's own file rather than the portal's.
+ *
+ * `keepRecentTokens` is the floor a compaction cannot go below: the most
+ * recent stretch of conversation is kept verbatim and only what is older gets
+ * summarised. pi's default of 20000 is most of a 64k window, which is why a
+ * compacted session can still read as a third full.
+ */
+export interface CompactionSettings {
+  enabled: boolean;
+  keepRecentTokens: number;
+}
+
+/** pi's own defaults, repeated here so the UI can show what it is inheriting. */
+export const COMPACTION_DEFAULTS: CompactionSettings = {
+  enabled: true,
+  keepRecentTokens: 20_000,
+};
+
+export function readCompactionSettings(): CompactionSettings {
+  const stored = readPiSettings().compaction;
+  const c = stored && typeof stored === "object" ? (stored as Record<string, unknown>) : {};
+  return {
+    enabled: c.enabled !== false,
+    keepRecentTokens:
+      typeof c.keepRecentTokens === "number" && c.keepRecentTokens > 0
+        ? c.keepRecentTokens
+        : COMPACTION_DEFAULTS.keepRecentTokens,
+  };
+}
+
+/**
+ * Merged into whatever else is in the file. pi writes here too, and the portal
+ * has no business dropping a key it does not know about.
+ */
+export function writeCompactionSettings(patch: Partial<CompactionSettings>): CompactionSettings {
+  const all = readPiSettings();
+  const current = all.compaction && typeof all.compaction === "object" ? all.compaction : {};
+  all.compaction = { ...current, ...patch };
+  mkdirSync(path.dirname(piSettingsPath()), { recursive: true });
+  writeFileSync(piSettingsPath(), JSON.stringify(all, null, 2) + "\n", "utf8");
+  return readCompactionSettings();
 }

--- a/server/src/pi-settings.ts
+++ b/server/src/pi-settings.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
 /**
@@ -62,14 +62,47 @@ export function readCompactionSettings(): CompactionSettings {
 }
 
 /**
- * Merged into whatever else is in the file. pi writes here too, and the portal
- * has no business dropping a key it does not know about.
+ * Change pi's settings file without losing what else is in it.
+ *
+ * Read-modify-write on a file pi also owns, so two precautions. The write is a
+ * temp file and a rename, which is atomic on the same filesystem — a reader
+ * arriving mid-write sees the old file whole rather than half of the new one.
+ * And the portal's own writes are serialised, so a slider released at the same
+ * moment as a Save cannot interleave and drop one of the two changes.
+ *
+ * What this cannot do is coordinate with pi itself: pi has no setter for most
+ * of these fields, so the portal writes the file directly, and a pi write
+ * landing between the read and the rename would still be lost. That window is
+ * milliseconds wide and pi only writes on a deliberate action, so it is a
+ * smaller risk than the alternative of reaching into its internals.
  */
-export function writeCompactionSettings(patch: Partial<CompactionSettings>): CompactionSettings {
-  const all = readPiSettings();
-  const current = all.compaction && typeof all.compaction === "object" ? all.compaction : {};
-  all.compaction = { ...current, ...patch };
-  mkdirSync(path.dirname(piSettingsPath()), { recursive: true });
-  writeFileSync(piSettingsPath(), JSON.stringify(all, null, 2) + "\n", "utf8");
+let writeChain: Promise<unknown> = Promise.resolve();
+
+export function updatePiSettings(
+  mutate: (settings: Record<string, unknown>) => void,
+): Promise<Record<string, unknown>> {
+  const next = writeChain.then(() => {
+    const all = readPiSettings();
+    mutate(all);
+    const file = piSettingsPath();
+    mkdirSync(path.dirname(file), { recursive: true });
+    const temp = `${file}.${process.pid}.tmp`;
+    writeFileSync(temp, JSON.stringify(all, null, 2) + "\n", "utf8");
+    renameSync(temp, file);
+    return all;
+  });
+  // Kept unbroken by a failure, or one bad write would wedge every later one.
+  writeChain = next.catch(() => {});
+  return next;
+}
+
+/** Merged, never replaced: the portal has no business dropping a key it does not know. */
+export async function writeCompactionSettings(
+  patch: Partial<CompactionSettings>,
+): Promise<CompactionSettings> {
+  await updatePiSettings((all) => {
+    const current = all.compaction && typeof all.compaction === "object" ? all.compaction : {};
+    all.compaction = { ...current, ...patch };
+  });
   return readCompactionSettings();
 }

--- a/server/src/pi/sdk-client.ts
+++ b/server/src/pi/sdk-client.ts
@@ -584,6 +584,19 @@ export class SdkPiClient extends EventEmitter implements PiClient {
     this.session.setThinkingLevel(level);
   }
 
+  /**
+   * Re-read pi's settings file into this session.
+   *
+   * A session takes a copy of the settings when it starts, so a compaction
+   * tuned in the UI would otherwise not reach anything already open — and the
+   * session you are looking at when you change it is exactly the one you meant.
+   * Only the file is re-read; anything set on this session was written there
+   * too, so nothing is lost.
+   */
+  async refreshSettings(): Promise<void> {
+    await this.session.settingsManager?.reload?.();
+  }
+
   async setAutoCompaction(enabled: boolean): Promise<void> {
     this.session.setAutoCompactionEnabled(enabled);
   }

--- a/server/src/pi/types.ts
+++ b/server/src/pi/types.ts
@@ -57,6 +57,8 @@ export interface PiClient extends EventEmitter {
   setModel(provider: string, modelId: string): Promise<void>;
   setThinkingLevel(level: string): Promise<void>;
   setAutoCompaction(enabled: boolean): Promise<void>;
+  /** Re-read pi's settings file. Optional: not every executor can. */
+  refreshSettings?(): Promise<void>;
   setAutoRetry(enabled: boolean): Promise<void>;
   compact(): Promise<void>;
   reload(): Promise<void>;

--- a/server/src/session-manager.ts
+++ b/server/src/session-manager.ts
@@ -156,6 +156,26 @@ class SessionManager extends EventEmitter {
     }
   }
 
+  /**
+   * Push a change to pi's settings file into every session already open.
+   *
+   * Without this, tuning compaction would apply to sessions started later and
+   * to nothing you can currently see. Failures are swallowed per session: one
+   * client that cannot reload is not a reason to fail the save.
+   */
+  async refreshSettings(): Promise<number> {
+    const live = [...this.live.values()];
+    const done = await Promise.all(
+      live.map((s) =>
+        s.client
+          .refreshSettings?.()
+          .then(() => true)
+          .catch(() => false) ?? Promise.resolve(false),
+      ),
+    );
+    return done.filter(Boolean).length;
+  }
+
   /** How far llama.cpp has got through the prompt. Straight out to the browser. */
   reportPrefill(sessionId: string, prefill: unknown): void {
     this.record(sessionId, "portal_prefill", prefill);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -114,6 +114,12 @@ export interface Workspace {
   isGit: boolean;
 }
 
+export interface CompactionSettings {
+  enabled: boolean;
+  /** The floor a compaction cannot go below — kept verbatim, never summarised. */
+  keepRecentTokens: number;
+}
+
 export interface PortalEvent {
   seq: number;
   type: string;
@@ -391,11 +397,20 @@ export const api = {
       /** What an unset field falls back to: env, else pi's settings.json. */
       defaults: GlobalSettings;
       piSettingsPath: string;
+      /** pi's own compaction tuning, which lives in its settings.json not ours. */
+      compaction: CompactionSettings;
+      compactionDefaults: CompactionSettings;
       executor: string;
       workspaceRoot: string;
     }>("/api/settings"),
-  saveSettings: (patch: Partial<GlobalSettings>) =>
-    json<{ settings: GlobalSettings; note: string }>("/api/settings", {
+  saveSettings: (patch: Partial<GlobalSettings> & { keepRecentTokens?: number }) =>
+    json<{
+      settings: GlobalSettings;
+      compaction: CompactionSettings;
+      /** How many open sessions took the new compaction settings. */
+      refreshed: number;
+      note: string;
+    }>("/api/settings", {
       method: "PUT",
       body: JSON.stringify(patch),
     }),

--- a/web/src/components/ConfigModal.tsx
+++ b/web/src/components/ConfigModal.tsx
@@ -22,6 +22,7 @@ import { api, type ExtensionInfo, type GlobalSettings, type ReportTarget, type R
 import { ChannelsPanel } from "./ChannelsPanel";
 import { SkillsPanel } from "./SkillsPanel";
 import { McpPanel } from "./McpPanel";
+import { KeepRecent, formatTokens } from "./KeepRecent";
 import { PeoplePanel } from "./PeoplePanel";
 import { PortalExtensions } from "./PortalExtensions";
 import { Modal } from "./Modal";
@@ -366,6 +367,8 @@ function GeneralPanel({ onError }: { onError: (e: string) => void }) {
   } | null>(null);
   const [saved, setSaved] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [keepRecent, setKeepRecent] = useState<number | null>(null);
+  const [applied, setApplied] = useState<string | null>(null);
 
   const load = () =>
     api
@@ -373,6 +376,7 @@ function GeneralPanel({ onError }: { onError: (e: string) => void }) {
       .then((r) => {
         setStored(r.stored);
         setDefaults(r.defaults);
+        setKeepRecent(r.compaction.keepRecentTokens);
         setMeta({
           executor: r.executor,
           workspaceRoot: r.workspaceRoot,
@@ -391,11 +395,19 @@ function GeneralPanel({ onError }: { onError: (e: string) => void }) {
     setBusy(true);
     try {
       // Sent even when blank: an empty value clears the override server-side.
-      await api.saveSettings({
+      const r = await api.saveSettings({
         provider: stored.provider ?? "",
         model: stored.model ?? "",
         thinkingLevel: stored.thinkingLevel ?? "",
+        ...(keepRecent !== null ? { keepRecentTokens: keepRecent } : {}),
       });
+      // Worth saying out loud: unlike the model default, this one reaches
+      // sessions that are already open.
+      setApplied(
+        r.refreshed > 0
+          ? `Applied to ${r.refreshed} open session${r.refreshed === 1 ? "" : "s"}`
+          : null,
+      );
       await load();
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
@@ -473,6 +485,24 @@ function GeneralPanel({ onError }: { onError: (e: string) => void }) {
               "Save defaults"
             )}
           </button>
+        </div>
+      </Section>
+
+      <Section
+        title="Compaction"
+        hint="What a compaction leaves untouched. The most recent stretch of a conversation is kept word for word; only what is older is replaced by a summary."
+      >
+        <div className="rounded-xl border border-line bg-raised/40 p-3">
+          {keepRecent !== null && (
+            <KeepRecent value={keepRecent} onChange={setKeepRecent} disabled={busy} />
+          )}
+          <p className="mt-2 text-xs text-fg-faint">
+            This is the floor a compacted session settles at, before the summary is added — pi's
+            default of {formatTokens(20000)} is a third of a 64k window, which is why compacting can
+            look as though it did nothing. Saved with the defaults above, and unlike them it reaches
+            sessions that are already open.
+          </p>
+          {applied && <p className="mt-1 text-xs text-ok">{applied}</p>}
         </div>
       </Section>
 

--- a/web/src/components/ConfigModal.tsx
+++ b/web/src/components/ConfigModal.tsx
@@ -389,25 +389,40 @@ function GeneralPanel({ onError }: { onError: (e: string) => void }) {
     load();
   }, []);
 
+  /**
+   * Saved on release, on its own.
+   *
+   * Not folded into Save defaults: that would submit whatever was loaded when
+   * the panel opened, so a value set from the context popup in the meantime
+   * would be silently rolled back by a save of unrelated fields.
+   */
+  const saveKeepRecent = async (tokens: number) => {
+    try {
+      const r = await api.saveSettings({ keepRecentTokens: tokens });
+      setKeepRecent(r.compaction.keepRecentTokens);
+      setApplied(
+        r.refreshed > 0
+          ? `Applied to ${r.refreshed} open session${r.refreshed === 1 ? "" : "s"}`
+          : "Saved",
+      );
+      setTimeout(() => setApplied(null), 3000);
+    } catch (e) {
+      onError((e as Error).message);
+      await load();
+    }
+  };
+
   if (!stored || !defaults) return <p className="text-sm text-fg-subtle">Loading…</p>;
 
   const save = async () => {
     setBusy(true);
     try {
       // Sent even when blank: an empty value clears the override server-side.
-      const r = await api.saveSettings({
+      await api.saveSettings({
         provider: stored.provider ?? "",
         model: stored.model ?? "",
         thinkingLevel: stored.thinkingLevel ?? "",
-        ...(keepRecent !== null ? { keepRecentTokens: keepRecent } : {}),
       });
-      // Worth saying out loud: unlike the model default, this one reaches
-      // sessions that are already open.
-      setApplied(
-        r.refreshed > 0
-          ? `Applied to ${r.refreshed} open session${r.refreshed === 1 ? "" : "s"}`
-          : null,
-      );
       await load();
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
@@ -494,13 +509,18 @@ function GeneralPanel({ onError }: { onError: (e: string) => void }) {
       >
         <div className="rounded-xl border border-line bg-raised/40 p-3">
           {keepRecent !== null && (
-            <KeepRecent value={keepRecent} onChange={setKeepRecent} disabled={busy} />
+            <KeepRecent
+              value={keepRecent}
+              onChange={setKeepRecent}
+              onCommit={saveKeepRecent}
+              disabled={busy}
+            />
           )}
           <p className="mt-2 text-xs text-fg-faint">
             This is the floor a compacted session settles at, before the summary is added — pi's
             default of {formatTokens(20000)} is a third of a 64k window, which is why compacting can
-            look as though it did nothing. Saved with the defaults above, and unlike them it reaches
-            sessions that are already open.
+            look as though it did nothing. Saved as you release the slider, and unlike the defaults
+            above it reaches sessions that are already open.
           </p>
           {applied && <p className="mt-1 text-xs text-ok">{applied}</p>}
         </div>

--- a/web/src/components/ConfigModal.tsx
+++ b/web/src/components/ConfigModal.tsx
@@ -22,7 +22,7 @@ import { api, type ExtensionInfo, type GlobalSettings, type ReportTarget, type R
 import { ChannelsPanel } from "./ChannelsPanel";
 import { SkillsPanel } from "./SkillsPanel";
 import { McpPanel } from "./McpPanel";
-import { KeepRecent, formatTokens } from "./KeepRecent";
+import { KeepRecent, formatTokens, useKeepRecentSave } from "./KeepRecent";
 import { PeoplePanel } from "./PeoplePanel";
 import { PortalExtensions } from "./PortalExtensions";
 import { Modal } from "./Modal";
@@ -396,21 +396,19 @@ function GeneralPanel({ onError }: { onError: (e: string) => void }) {
    * the panel opened, so a value set from the context popup in the meantime
    * would be silently rolled back by a save of unrelated fields.
    */
-  const saveKeepRecent = async (tokens: number) => {
-    try {
-      const r = await api.saveSettings({ keepRecentTokens: tokens });
-      setKeepRecent(r.compaction.keepRecentTokens);
+  const saveKeepRecent = useKeepRecentSave(
+    (compaction, refreshed) => {
+      setKeepRecent(compaction.keepRecentTokens);
       setApplied(
-        r.refreshed > 0
-          ? `Applied to ${r.refreshed} open session${r.refreshed === 1 ? "" : "s"}`
-          : "Saved",
+        refreshed > 0 ? `Applied to ${refreshed} open session${refreshed === 1 ? "" : "s"}` : "Saved",
       );
       setTimeout(() => setApplied(null), 3000);
-    } catch (e) {
-      onError((e as Error).message);
-      await load();
-    }
-  };
+    },
+    (error) => {
+      onError(error.message);
+      void load();
+    },
+  );
 
   if (!stored || !defaults) return <p className="text-sm text-fg-subtle">Loading…</p>;
 

--- a/web/src/components/ContextPill.tsx
+++ b/web/src/components/ContextPill.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { LuChevronRight, LuRefreshCw } from "react-icons/lu";
 import { api, type PiConfig } from "../api";
-import { KeepRecent } from "./KeepRecent";
+import { KeepRecent, useKeepRecentSave } from "./KeepRecent";
 
 /**
  * Context fill is the number that decides whether a long session keeps working,
@@ -99,15 +99,10 @@ export function ContextPill({
    * Saved when the drag ends, not on every step, and applied to open sessions
    * by the server — including this one, so the next compaction uses it.
    */
-  const saveKeepRecent = async (tokens: number) => {
-    setNote(null);
-    try {
-      const r = await api.saveSettings({ keepRecentTokens: tokens });
-      setKeepRecent(r.compaction.keepRecentTokens);
-    } catch (e) {
-      setNote({ text: (e as Error).message, error: true });
-    }
-  };
+  const saveKeepRecent = useKeepRecentSave(
+    (compaction) => setKeepRecent(compaction.keepRecentTokens),
+    (error) => setNote({ text: error.message, error: true }),
+  );
 
   const toggleAuto = async () => {
     setBusy("auto");

--- a/web/src/components/ContextPill.tsx
+++ b/web/src/components/ContextPill.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { LuChevronRight, LuRefreshCw } from "react-icons/lu";
 import { api, type PiConfig } from "../api";
+import { KeepRecent } from "./KeepRecent";
 
 /**
  * Context fill is the number that decides whether a long session keeps working,
@@ -52,9 +53,19 @@ export function ContextPill({
 }) {
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState<null | "compact" | "auto">(null);
+  /** Read when the popup opens rather than with the transcript — it is pi's file. */
+  const [keepRecent, setKeepRecent] = useState<number | null>(null);
   /** pi refuses to compact a short session, so its reason has to be visible. */
   const [note, setNote] = useState<{ text: string; error: boolean } | null>(null);
   const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open || keepRecent !== null) return;
+    api
+      .settings()
+      .then((r) => setKeepRecent(r.compaction.keepRecentTokens))
+      .catch(() => {});
+  }, [open, keepRecent]);
 
   useEffect(() => {
     if (!open) return;
@@ -81,6 +92,20 @@ export function ContextPill({
       setNote({ text: (e as Error).message, error: true });
     } finally {
       setBusy(null);
+    }
+  };
+
+  /**
+   * Saved when the drag ends, not on every step, and applied to open sessions
+   * by the server — including this one, so the next compaction uses it.
+   */
+  const saveKeepRecent = async (tokens: number) => {
+    setNote(null);
+    try {
+      const r = await api.saveSettings({ keepRecentTokens: tokens });
+      setKeepRecent(r.compaction.keepRecentTokens);
+    } catch (e) {
+      setNote({ text: (e as Error).message, error: true });
     }
   };
 
@@ -161,6 +186,22 @@ export function ContextPill({
               />
             </span>
           </button>
+
+          {keepRecent !== null && (
+            <div className="mt-2 rounded-lg bg-raised/40 px-2 py-2">
+              <KeepRecent
+                value={keepRecent}
+                contextWindow={usage.contextWindow}
+                onChange={setKeepRecent}
+                onCommit={saveKeepRecent}
+                disabled={busy !== null}
+              />
+              <p className="mt-1.5 text-[11px] text-fg-faint">
+                Kept word for word; only what is older is summarised. This is where a compaction
+                lands, before the summary is added.
+              </p>
+            </div>
+          )}
 
           <button
             type="button"

--- a/web/src/components/KeepRecent.tsx
+++ b/web/src/components/KeepRecent.tsx
@@ -82,36 +82,64 @@ export function KeepRecent({
 }
 
 /**
- * Save the value, ignoring anything a newer save has already superseded.
+ * Save the value, in order, and only the value that is still current.
  *
  * A slider driven from the keyboard fires a commit per keypress, so several
- * saves can be in flight at once and they do not have to come back in order.
- * An earlier reply landing last would set the control to a value the server no
- * longer holds — the number would appear to jump backwards on its own. Only
- * the newest request is allowed to touch state, for failures as well as
- * successes.
+ * saves are asked for in quick succession. Two problems, and guarding the
+ * callbacks only solves the visible one.
  *
- * Shared because both places that offer this control had the same race, and a
- * fix in one of them is a fix that drifts.
+ * Requests do not have to come back in the order they were sent. An earlier
+ * reply landing last would repaint the control with a value the server no
+ * longer holds — the number appears to jump backwards on its own. Worse, an
+ * earlier request can *arrive* last, and then the server ends up storing the
+ * older value while the control quite correctly shows the newer one. No amount
+ * of care on the client's side of the reply fixes that; the writes themselves
+ * have to be ordered.
+ *
+ * So they run one at a time, and a value that a newer commit has already
+ * replaced is dropped when its turn comes rather than sent — the newer one is
+ * behind it in the queue and will write. Dragging a slider across twenty steps
+ * makes two requests, not twenty, and the last one holds the value you left it
+ * on.
+ *
+ * All of this is module level rather than per component: it is one setting,
+ * and the two places that offer it must not race each other either.
  */
+let queue: Promise<unknown> = Promise.resolve();
+let newest = 0;
+
+/** Skipped rather than sent, when something newer is already waiting behind it. */
+const SUPERSEDED = Symbol("superseded");
+
 export function useKeepRecentSave(
   onSaved: (compaction: CompactionSettings, refreshed: number) => void,
   onFailed: (error: Error) => void,
 ) {
-  const latest = useRef(0);
   const saved = useRef(onSaved);
   const failed = useRef(onFailed);
   saved.current = onSaved;
   failed.current = onFailed;
 
   return useCallback(async (tokens: number) => {
-    const mine = ++latest.current;
+    const mine = ++newest;
+    const run = async () => {
+      if (mine !== newest) return SUPERSEDED;
+      return api.saveSettings({ keepRecentTokens: tokens });
+    };
+    // Chained off the previous save whether it worked or not, or one failure
+    // would stop every later save from ever being sent.
+    const next = queue.then(run, run);
+    queue = next.then(
+      () => {},
+      () => {},
+    );
+
     try {
-      const r = await api.saveSettings({ keepRecentTokens: tokens });
-      if (latest.current !== mine) return;
+      const r = await next;
+      if (r === SUPERSEDED || mine !== newest) return;
       saved.current(r.compaction, r.refreshed);
     } catch (e) {
-      if (latest.current !== mine) return;
+      if (mine !== newest) return;
       failed.current(e as Error);
     }
   }, []);

--- a/web/src/components/KeepRecent.tsx
+++ b/web/src/components/KeepRecent.tsx
@@ -1,3 +1,6 @@
+import { useCallback, useRef } from "react";
+import { api, type CompactionSettings } from "../api";
+
 /**
  * How much of a conversation compaction leaves alone.
  *
@@ -76,4 +79,40 @@ export function KeepRecent({
       </div>
     </div>
   );
+}
+
+/**
+ * Save the value, ignoring anything a newer save has already superseded.
+ *
+ * A slider driven from the keyboard fires a commit per keypress, so several
+ * saves can be in flight at once and they do not have to come back in order.
+ * An earlier reply landing last would set the control to a value the server no
+ * longer holds — the number would appear to jump backwards on its own. Only
+ * the newest request is allowed to touch state, for failures as well as
+ * successes.
+ *
+ * Shared because both places that offer this control had the same race, and a
+ * fix in one of them is a fix that drifts.
+ */
+export function useKeepRecentSave(
+  onSaved: (compaction: CompactionSettings, refreshed: number) => void,
+  onFailed: (error: Error) => void,
+) {
+  const latest = useRef(0);
+  const saved = useRef(onSaved);
+  const failed = useRef(onFailed);
+  saved.current = onSaved;
+  failed.current = onFailed;
+
+  return useCallback(async (tokens: number) => {
+    const mine = ++latest.current;
+    try {
+      const r = await api.saveSettings({ keepRecentTokens: tokens });
+      if (latest.current !== mine) return;
+      saved.current(r.compaction, r.refreshed);
+    } catch (e) {
+      if (latest.current !== mine) return;
+      failed.current(e as Error);
+    }
+  }, []);
 }

--- a/web/src/components/KeepRecent.tsx
+++ b/web/src/components/KeepRecent.tsx
@@ -1,0 +1,68 @@
+/**
+ * How much of a conversation compaction leaves alone.
+ *
+ * The number that decides how full a session is *after* it has been compacted:
+ * the most recent stretch is kept word for word and only what is older gets
+ * summarised. pi's default is 20,000 tokens, which on a 64k model is a third of
+ * the window spent before the summary is even added — so a compacted session
+ * reads as still half full and it looks as though compaction did nothing.
+ *
+ * A slider rather than a number field because the useful question is not "how
+ * many tokens" but "how much of my window", and that is a shape, not a figure.
+ */
+
+const MIN = 2_000;
+const STEP = 1_000;
+/** Enough headroom for a large window without making the useful end unusable. */
+const FALLBACK_MAX = 48_000;
+
+export const formatTokens = (n: number) =>
+  n >= 1000 ? `${(n / 1000).toFixed(n % 1000 === 0 ? 0 : 1)}k` : String(n);
+
+export function KeepRecent({
+  value,
+  onChange,
+  onCommit,
+  contextWindow,
+  disabled,
+}: {
+  value: number;
+  onChange: (next: number) => void;
+  /** Fired when the drag ends, so a save is not sent on every pixel. */
+  onCommit?: (next: number) => void;
+  /** The model's window, when it is known — turns tokens into a proportion. */
+  contextWindow?: number;
+  disabled?: boolean;
+}) {
+  const max = contextWindow && contextWindow > MIN ? Math.min(contextWindow, 200_000) : FALLBACK_MAX;
+  const clamped = Math.min(Math.max(value, MIN), max);
+  const share = contextWindow ? (clamped / contextWindow) * 100 : null;
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-xs text-fg-subtle">Keep recent</span>
+        <span className="tabular-nums text-xs text-fg">
+          {formatTokens(clamped)} tokens
+          {share !== null && <span className="ml-1 text-fg-faint">· {share.toFixed(0)}% of window</span>}
+        </span>
+      </div>
+      <input
+        type="range"
+        min={MIN}
+        max={max}
+        step={STEP}
+        value={clamped}
+        disabled={disabled}
+        onChange={(e) => onChange(Number(e.target.value))}
+        onPointerUp={(e) => onCommit?.(Number((e.target as HTMLInputElement).value))}
+        onKeyUp={(e) => onCommit?.(Number((e.target as HTMLInputElement).value))}
+        className="mt-1.5 h-1 w-full cursor-pointer appearance-none rounded-full bg-raised accent-accent disabled:opacity-40"
+      />
+      <div className="mt-1 flex justify-between text-[10px] text-fg-faint">
+        <span>{formatTokens(MIN)}</span>
+        <span>{formatTokens(max)}</span>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/KeepRecent.tsx
+++ b/web/src/components/KeepRecent.tsx
@@ -11,9 +11,17 @@
  * many tokens" but "how much of my window", and that is a shape, not a figure.
  */
 
-const MIN = 2_000;
+/** The API's own floor, so a stored value can always be shown as what it is. */
+const MIN = 1_000;
 const STEP = 1_000;
-/** Enough headroom for a large window without making the useful end unusable. */
+/**
+ * Where the slider ends when the window is unknown.
+ *
+ * Not the API's ceiling of 500,000: a slider spanning that would put every
+ * useful value in its first few pixels. A value already above this raises the
+ * end instead, so a setting made elsewhere is never misrepresented or clamped
+ * by a control that merely cannot draw it.
+ */
 const FALLBACK_MAX = 48_000;
 
 export const formatTokens = (n: number) =>
@@ -34,7 +42,9 @@ export function KeepRecent({
   contextWindow?: number;
   disabled?: boolean;
 }) {
-  const max = contextWindow && contextWindow > MIN ? Math.min(contextWindow, 200_000) : FALLBACK_MAX;
+  const ceiling =
+    contextWindow && contextWindow > MIN ? Math.min(contextWindow, 200_000) : FALLBACK_MAX;
+  const max = Math.max(ceiling, value);
   const clamped = Math.min(Math.max(value, MIN), max);
   const share = contextWindow ? (clamped / contextWindow) * 100 : null;
 
@@ -57,6 +67,7 @@ export function KeepRecent({
         onChange={(e) => onChange(Number(e.target.value))}
         onPointerUp={(e) => onCommit?.(Number((e.target as HTMLInputElement).value))}
         onKeyUp={(e) => onCommit?.(Number((e.target as HTMLInputElement).value))}
+        aria-label="Tokens kept verbatim by compaction"
         className="mt-1.5 h-1 w-full cursor-pointer appearance-none rounded-full bg-raised accent-accent disabled:opacity-40"
       />
       <div className="mt-1 flex justify-between text-[10px] text-fg-faint">


### PR DESCRIPTION
## Why

Compacting a 64k session left it at 35% and looked as though it had barely worked. It hadn't misbehaved — pi keeps the most recent `keepRecentTokens` **verbatim** and only summarises what is older, and the default of 20,000 is a third of that window before the summary is even added. From the real compaction record on the live portal:

| | tokens | % of 64k |
|---|---|---|
| before | 38,016 | 59.4% |
| after | 22,394 | 35.0% |
| kept verbatim (`keepRecentTokens`) | 20,000 | 31.3% |
| summary | ~2,423 | 3.8% |

`20000 + 2423 = 22423` against an actual `22394`. The entire post-compaction floor is that one setting, and it was reachable only by hand-editing pi's `settings.json`.

## What

A slider in two places, both writing the same value:

- **Under the context donut**, where the question actually occurs to you. It knows the model's window, so it shows the share rather than a bare token count — which is the form the question is asked in.
- **Settings → General**, as a portal-wide default.

Saved on pointer release rather than on every step.

## Reaching sessions that are already open

A session copies the settings when it starts, so writing the file alone would apply to sessions started later and to nothing you can currently see — including the session you were looking at when you moved the slider.

`session.settingsManager` is public and has `reload()`, so the server reloads every live client after a save and reports how many took it. This is safe because everything a session can set (the auto-compact toggle) is written to that same file by `save()`, so a reload cannot lose it.

## Verified on a throwaway container

Built the branch, ran it on `127.0.0.1:4101`, and drove it over the API:

- read/write round trip; the value merges into `settings.json` without disturbing `enabled` or neighbouring keys
- out-of-range rejected rather than silently clamped (`500` → 400)
- `refreshed: 1` with a live session open
- and the part that matters — a 23.4k session compacted with `keepRecentTokens: 6000` landed at **9,436 tokens (14.7%)**, where the default would have left it unable to compact at all

## Note

Values are rejected outside 1,000–500,000 rather than clamped: a number typed into a box that silently becomes a different number is worse than being told.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controls for configuring conversation compaction and recent-token retention.
  * Displayed retention as token counts and context-window percentages with adjustable sliders.
  * Exposed compaction status, defaults, and refreshed-session counts in settings.
  * Automatically refreshed open sessions after valid changes.

* **Bug Fixes**
  * Added validation for invalid token values with clear errors.
  * Prevented incompatible settings combinations from being saved.
  * Preserved existing settings when updating compaction options.
  * Reloaded settings when saving fails to keep the interface accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->