### PR TITLE
fix(sessions): start pi once per session

### DIFF
--- a/server/src/session-manager.ts
+++ b/server/src/session-manager.ts
@@ -181,10 +181,34 @@ class SessionManager extends EventEmitter {
     this.record(sessionId, "portal_prefill", prefill);
   }
 
-  private async ensureClient(sessionId: string): Promise<PiClient> {
+  /**
+   * Start pi for a session, once.
+   *
+   * Two callers arriving on a cold session both used to get past the check
+   * below and both launch. The later `live.set()` then dropped the first on
+   * the floor: a pi session still running, still subscribed to its own events,
+   * with an executor nobody would ever clean up — and a Stop that reached
+   * whichever one happened to be in the map.
+   *
+   * askNow() makes it easy to hit, because it starts a client of its own
+   * before it prompts, and any two requests landing together on a session
+   * nobody has opened yet will do it.
+   */
+  private ensureClient(sessionId: string): Promise<PiClient> {
     const existing = this.live.get(sessionId);
-    if (existing?.client.running) return existing.client;
+    if (existing?.client.running) return Promise.resolve(existing.client);
 
+    const starting = this.starting.get(sessionId);
+    if (starting) return starting;
+
+    // Cleared whether it worked or not, so a failed start does not leave the
+    // session unable to try again.
+    const launch = this.startClient(sessionId).finally(() => this.starting.delete(sessionId));
+    this.starting.set(sessionId, launch);
+    return launch;
+  }
+
+  private async startClient(sessionId: string): Promise<PiClient> {
     const session = getSession(sessionId);
     if (!session) throw new Error(`Unknown session ${sessionId}`);
 
@@ -281,6 +305,9 @@ class SessionManager extends EventEmitter {
 
   /** A Stop that arrived before there was anything to stop. */
   private cancelPending = new Set<string>();
+
+  /** Client startup in flight, so two callers cannot launch two of them. */
+  private starting = new Map<string, Promise<PiClient>>();
 
   /** Move a session's status and tell whoever is watching, in that order. */
   private mark(sessionId: string, status: "running" | "idle"): void {


### PR DESCRIPTION
Closes #11. Found by CodeRabbit while reviewing #10, but pre-existing and unrelated to that PR, so it was raised separately rather than folded in.

## The problem

`ensureClient()` checks `this.live` and, on a miss, launches pi:

```ts
const existing = this.live.get(sessionId);
if (existing?.client.running) return existing.client;
...
const client = await executor.launch({...});
this.live.set(sessionId, { client, executor });
```

Two callers arriving on a cold session both get past that check and both launch. The later `live.set()` drops the first — a pi session **still running**, still subscribed to its own events, with an executor nobody will ever clean up. `abort()` and `stop()` then act on whichever one happens to be in the map.

`askNow()` makes it easy to reach: it calls `ensureClient()` itself, then calls `prompt()`, which calls it again. Any two requests landing together on a session nobody has opened yet will do it — a page being opened while a channel message arrives, for instance.

## The fix

Startup is single-flight per session: concurrent callers wait on the same launch. The entry is cleared whether the launch succeeds or fails, so one bad start does not leave the session permanently unable to try again.

## Reproduced first

A harness mirroring `ensureClient` with a slow launch, so the callers overlap the way they do on a cold session:

```
PASS  without single-flight: the bug reproduces  launched=3 orphaned=2 distinct clients handed out=3
PASS  with single-flight: one client, none orphaned  launched=1 orphaned=0 distinct clients handed out=1
PASS  a failed start clears the way for a retry  pending=0
```

That checks the shape of the code rather than the real class, which needs a database and a pi runtime to instantiate — so it is not an integration test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate session startups when multiple requests begin at the same time.
  - Improved session reliability by avoiding orphaned client instances during concurrent launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->